### PR TITLE
ELB Generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,43 @@ Module usage:
      module "fake_elb" {
        source         = "git::https://github.com/UKHomeOffice/acp-tf-elb?ref=master"
 
-       name            = "my_elb_name"
-       environment     = "dev"            # by default both Name and Env is added to the tags
-       dns_name        = "site"           # or defaults to var.name
-       dns_zone        = "example.com"
+       name                 = "my_elb_name"
+       environment          = "dev"            # by default both Name and Env is added to the tags
+       dns_name             = "site"           # or defaults to var.name
+       dns_zone             = "example.com"
+       proxy_protocol       = true
+       proxy_protocol_ports = ["80", "443"]
+       vpc_id               = "vpc-32323232"
+
+       ingress = [
+         {
+           "cidr"     = "0.0.0.0/0" # optional as it defaults
+           "port"     = "80"
+           "protocol" = "tcp" # optional as it default
+         },
+         {
+           "port"     = "443"
+           "protocol" = "tcp"
+         },
+       ]
+
+       # egress = []  same as above, defaults to a permit all
+
+       listeners = [
+         {
+           instance_port     = "30100"
+           lb_port           = "80"
+           instance_protocol = "tcp"
+           lb_protocol       = "tcp"
+         },
+         {
+           instance_port     = "30101"
+           lb_port           = "443"
+           instance_protocol = "tcp"
+           lb_protocol       = "tcp"
+         },
+       ]
+
        tags            = {
          Role = "some_tag"
        }
@@ -14,10 +47,6 @@ Module usage:
        subnet_tags {
          Role = "some_tag"
        }
-       cidr_access     = [ "1.0.0.1/32" ] # defaults to 0.0.0.0/0
-       http_node_port  = "30204"
-       https_node_port = "30205"
-       proxy_protocol  = true
      }
 
 
@@ -33,6 +62,7 @@ Module usage:
 | dns_name | An optional hostname to add to the hosting zone, otherwise defaults to var.name | `` | no |
 | dns_type | The dns record type to use when adding the dns entry | `A` | no |
 | dns_zone | The AWS route53 domain name hosting the dns entry, i.e. example.com | - | yes |
+| egress | A collection of maps which has port and optional protocol and cidr for egress rules | `<list>` | no |
 | elb_role_tag | The role tag applied to the subnets used for ELB, i.e. Role = elb-subnet | `elb-subnets` | no |
 | environment | An envionment name for the ELB, i.e. prod, dev, ci etc and used to search for assets | - | yes |
 | health_check_interval | The interval between health checks | `30` | no |
@@ -41,14 +71,16 @@ Module usage:
 | health_check_timeout | The timeout placed on the health checks | `10` | no |
 | health_check_unhealthy | The threshold of failed checks before marked unhealthy | `3` | no |
 | idle_timeout | The timeout applie to idle ELB connections | `120` | no |
+| ingress | A collection of maps which has port and optional protocol and cidr for ingress rules | - | yes |
 | internal | Indicates if the ELB should be an internal load balancer, defaults to true | `true` | no |
-| listeners | A collection of maps which has port, node_port, protocol and cidr | - | yes |
+| listeners | A collection of elb listeners as defined by the provider | - | yes |
 | name | A descriptive name for this ELB | - | yes |
 | proxy_protocol | Indicates if proxy protocol should be enabled on node ports, defaults to false | `false` | no |
+| proxy_protocol_ports | If enabled a list of lb ports which should use proxy protocol | `<list>` | no |
 | security_groups | An optional list of security groups added to the created ELB | `<list>` | no |
 | subnet_tags | A map of tags used to filter the subnets you want the ELB attached | `<map>` | no |
 | tags | A map of tags which will be added to the ELB cloud tags, by default Name, Env and KubernetesCluster is added | `<map>` | no |
-| vpc_id | The VPC ID to create the resources within | - | yes |
+| vpc_id | The VPC is we should build the ELB into | - | yes |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Module usage:
 | Name | Description | Default | Required |
 |------|-------------|:-----:|:-----:|
 | attach_elb | Autoscaling group name used to find the autoscaling group to attach ELB | `` | no |
-| cidr_access | A collection of network CIDR able to access this ELB, defaults to all | `<list>` | no |
 | connection_draining | Whether the ELB should drain connections | `true` | no |
 | connection_draining_timeout | The timeout for draining connections from the ELB | `120` | no |
 | cross_zone | Should the ELB create be cross zone load balancing | `true` | no |
@@ -37,16 +36,13 @@ Module usage:
 | elb_role_tag | The role tag applied to the subnets used for ELB, i.e. Role = elb-subnet | `elb-subnets` | no |
 | environment | An envionment name for the ELB, i.e. prod, dev, ci etc and used to search for assets | - | yes |
 | health_check_interval | The interval between health checks | `30` | no |
-| health_check_port | The node port we should use on the health check, defaults to var.https_node_port | `` | no |
+| health_check_port | The node port we should use on the health check | - | yes |
 | health_check_threshold | The threshold for health checks marked healthy | `2` | no |
 | health_check_timeout | The timeout placed on the health checks | `10` | no |
 | health_check_unhealthy | The threshold of failed checks before marked unhealthy | `3` | no |
-| http_node_port | The http node port the ELB should be forwarding to | - | yes |
-| http_port | The ingress port running http | `80` | no |
-| https_node_port | The https node port the ELB should be forwarding to | - | yes |
-| https_port | the ingress port which is running https | `443` | no |
 | idle_timeout | The timeout applie to idle ELB connections | `120` | no |
 | internal | Indicates if the ELB should be an internal load balancer, defaults to true | `true` | no |
+| listeners | A collection of maps which has port, node_port, protocol and cidr | - | yes |
 | name | A descriptive name for this ELB | - | yes |
 | proxy_protocol | Indicates if proxy protocol should be enabled on node ports, defaults to false | `false` | no |
 | security_groups | An optional list of security groups added to the created ELB | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -4,10 +4,43 @@
  *      module "fake_elb" {
  *        source         = "git::https://github.com/UKHomeOffice/acp-tf-elb?ref=master"
  *
- *        name            = "my_elb_name"
- *        environment     = "dev"            # by default both Name and Env is added to the tags
- *        dns_name        = "site"           # or defaults to var.name
- *        dns_zone        = "example.com"
+ *        name                 = "my_elb_name"
+ *        environment          = "dev"            # by default both Name and Env is added to the tags
+ *        dns_name             = "site"           # or defaults to var.name
+ *        dns_zone             = "example.com"
+ *        proxy_protocol       = true
+ *        proxy_protocol_ports = ["80", "443"]
+ *        vpc_id               = "vpc-32323232"
+ *
+ *        ingress = [
+ *          {
+ *            "cidr"     = "0.0.0.0/0" # optional as it defaults
+ *            "port"     = "80"
+ *            "protocol" = "tcp" # optional as it default
+ *          },
+ *          {
+ *            "port"     = "443"
+ *            "protocol" = "tcp"
+ *          },
+ *        ]
+ *
+ *        # egress = []  same as above, defaults to a permit all
+ *
+ *        listeners = [
+ *          {
+ *            instance_port     = "30100"
+ *            lb_port           = "80"
+ *            instance_protocol = "tcp"
+ *            lb_protocol       = "tcp"
+ *          },
+ *          {
+ *            instance_port     = "30101"
+ *            lb_port           = "443"
+ *            instance_protocol = "tcp"
+ *            lb_protocol       = "tcp"
+ *          },
+ *        ]
+ *
  *        tags            = {
  *          Role = "some_tag"
  *        }
@@ -15,10 +48,6 @@
  *        subnet_tags {
  *          Role = "some_tag"
  *        }
- *        cidr_access     = [ "1.0.0.1/32" ] # defaults to 0.0.0.0/0
- *        http_node_port  = "30204"
- *        https_node_port = "30205"
- *        proxy_protocol  = true
  *      }
  *
  */
@@ -98,7 +127,7 @@ resource "aws_elb" "elb" {
 resource "aws_proxy_protocol_policy" "proxy_protocol" {
   count = "${var.proxy_protocol ? 1 : 0}"
 
-  instance_ports = ["${matchkeys(values(var.listeners[count.index]), keys(var.listeners[count.index]), list("proxy_protocol"))}"]
+  instance_ports = ["${var.proxy_protocol_ports}"]
   load_balancer  = "${aws_elb.elb.name}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -45,26 +45,26 @@ resource "aws_security_group" "sg" {
 
 ## Ingress Rules
 resource "aws_security_group_rule" "ingress" {
-  count = "${length(var.listeners)}"
+  count = "${length(var.ingress)}"
 
   type              = "ingress"
   security_group_id = "${aws_security_group.sg.id}"
-  protocol          = "${lookup(var.listeners[count.index], "protocol", "tcp")}"
-  from_port         = "${lookup(var.listeners[count.index], "port")}"
-  to_port           = "${lookup(var.listeners[count.index], "port")}"
-  cidr_blocks       = ["${lookup(var.listeners[count.index], "cidr", "0.0.0.0/0")}"]
+  protocol          = "${lookup(var.ingress[count.index], "protocol", "tcp")}"
+  from_port         = "${lookup(var.ingress[count.index], "port")}"
+  to_port           = "${lookup(var.ingress[count.index], "port")}"
+  cidr_blocks       = "${lookup(var.ingress[count.index], "cidr", "0.0.0.0/0")}"
 }
 
 ## Engress Rules
 resource "aws_security_group_rule" "egress" {
-  count = "${length(var.listeners)}"
+  count = "${length(var.egress)}"
 
   type              = "egress"
   security_group_id = "${aws_security_group.sg.id}"
-  protocol          = "${lookup(var.listeners[count.index], "protocol", "tcp")}"
-  from_port         = "${lookup(var.listeners[count.index], "node_port")}"
-  to_port           = "${lookup(var.listeners[count.index], "node_port")}"
-  cidr_blocks       = ["${lookup(var.listeners[count.index], "cidr", "0.0.0.0/0")}"]
+  protocol          = "${lookup(var.egress[count.index], "protocol", "tcp")}"
+  from_port         = "${lookup(var.egress[count.index], "port")}"
+  to_port           = "${lookup(var.egress[count.index], "port")}"
+  cidr_blocks       = "${lookup(var.ingress[count.index], "cidr", "0.0.0.0/0")}"
 }
 
 ## The ELB we are creating

--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_security_group_rule" "ingress" {
   protocol          = "${lookup(var.ingress[count.index], "protocol", "tcp")}"
   from_port         = "${lookup(var.ingress[count.index], "port")}"
   to_port           = "${lookup(var.ingress[count.index], "port")}"
-  cidr_blocks       = "${lookup(var.ingress[count.index], "cidr", "0.0.0.0/0")}"
+  cidr_blocks       = [ "${lookup(var.ingress[count.index], "cidr", "0.0.0.0/0")}" ]
 }
 
 ## Engress Rules
@@ -64,7 +64,7 @@ resource "aws_security_group_rule" "egress" {
   protocol          = "${lookup(var.egress[count.index], "protocol", "tcp")}"
   from_port         = "${lookup(var.egress[count.index], "port")}"
   to_port           = "${lookup(var.egress[count.index], "port")}"
-  cidr_blocks       = "${lookup(var.ingress[count.index], "cidr", "0.0.0.0/0")}"
+  cidr_blocks       = [ "${lookup(var.ingress[count.index], "cidr", "0.0.0.0/0")}" ]
 }
 
 ## The ELB we are creating

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,11 @@
  *
  */
 
+# Get the VPC for this environment
+data "aws_vpc" "selected" {
+  id = "${var.vpc_id}"
+}
+
 # Get a list of ELB subnets
 data "aws_subnet_ids" "selected" {
   vpc_id = "${var.vpc_id}"
@@ -38,7 +43,7 @@ data "aws_route53_zone" "selected" {
 resource "aws_security_group" "sg" {
   name        = "${var.environment}-${var.name}-elb"
   description = "The security group for ELB on service: ${var.name}, environment: ${var.environment}"
-  vpc_id      = "${var.vpc_id}"
+  vpc_id      = "${data.aws_vpc.selected.id}"
 
   tags = "${merge(var.tags, map("Name", format("%s-%s-elb", var.environment, var.name)), map("Env", var.environment), map("KubernetesCluster", var.environment))}"
 }
@@ -52,7 +57,7 @@ resource "aws_security_group_rule" "ingress" {
   protocol          = "${lookup(var.ingress[count.index], "protocol", "tcp")}"
   from_port         = "${lookup(var.ingress[count.index], "port")}"
   to_port           = "${lookup(var.ingress[count.index], "port")}"
-  cidr_blocks       = [ "${lookup(var.ingress[count.index], "cidr", "0.0.0.0/0")}" ]
+  cidr_blocks       = ["${lookup(var.ingress[count.index], "cidr", "0.0.0.0/0")}"]
 }
 
 ## Engress Rules
@@ -64,7 +69,7 @@ resource "aws_security_group_rule" "egress" {
   protocol          = "${lookup(var.egress[count.index], "protocol", "tcp")}"
   from_port         = "${lookup(var.egress[count.index], "port")}"
   to_port           = "${lookup(var.egress[count.index], "port")}"
-  cidr_blocks       = [ "${lookup(var.ingress[count.index], "cidr", "0.0.0.0/0")}" ]
+  cidr_blocks       = ["${lookup(var.ingress[count.index], "cidr", "0.0.0.0/0")}"]
 }
 
 ## The ELB we are creating

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ data "aws_vpc" "selected" {
 
 # Get a list of ELB subnets
 data "aws_subnet_ids" "selected" {
-  vpc_id = "${var.vpc_id}"
+  vpc_id = "${data.aws_vpc.selected.id}"
   tags   = "${var.subnet_tags}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,11 @@ variable "proxy_protocol" {
   default     = false
 }
 
+variable "proxy_protocol_ports" {
+  description = "If enabled a list of lb ports which should use proxy protocol"
+  default     = []
+}
+
 variable "security_groups" {
   description = "An optional list of security groups added to the created ELB"
   default     = []
@@ -122,5 +127,5 @@ variable "health_check_timeout" {
 }
 
 variable "vpc_id" {
-  description = "The VPC is we should to build the ELB into"
+  description = "The VPC is we should build the ELB into"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -122,5 +122,5 @@ variable "health_check_timeout" {
 }
 
 variable "vpc_id" {
-  description = "The VPC ID to create the resources within"
+  description = "The VPC is we should to build the ELB into"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,8 +11,25 @@ variable "dns_zone" {
 }
 
 variable "listeners" {
-  description = "A collection of maps which has port, node_port, protocol and cidr"
+  description = "A collection of elb listeners as defined by the provider"
   type        = "list"
+}
+
+variable "ingress" {
+  description = "A collection of maps which has port and optional protocol and cidr for ingress rules"
+  type        = "list"
+}
+
+variable "egress" {
+  description = "A collection of maps which has port and optional protocol and cidr for egress rules"
+
+  default = [
+    {
+      cidr     = "0.0.0.0/0"
+      port     = "-1"
+      protocol = "-1"
+    },
+  ]
 }
 
 variable "attach_elb" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,12 +10,8 @@ variable "dns_zone" {
   description = "The AWS route53 domain name hosting the dns entry, i.e. example.com"
 }
 
-variable "http_node_port" {
-  description = "The http node port the ELB should be forwarding to"
-}
-
-variable "https_node_port" {
-  description = "The https node port the ELB should be forwarding to"
+variable "listeners" {
+  description = "A collection of maps which has port, node_port, protocol and cidr"
 }
 
 variable "attach_elb" {
@@ -24,8 +20,7 @@ variable "attach_elb" {
 }
 
 variable "health_check_port" {
-  description = "The node port we should use on the health check, defaults to var.https_node_port"
-  default     = ""
+  description = "The node port we should use on the health check"
 }
 
 variable "dns_name" {
@@ -58,24 +53,9 @@ variable "security_groups" {
   default     = []
 }
 
-variable "cidr_access" {
-  description = "A collection of network CIDR able to access this ELB, defaults to all"
-  default     = ["0.0.0.0/0"]
-}
-
 variable "tags" {
   description = "A map of tags which will be added to the ELB cloud tags, by default Name, Env and KubernetesCluster is added"
   default     = {}
-}
-
-variable "http_port" {
-  description = "The ingress port running http"
-  default     = "80"
-}
-
-variable "https_port" {
-  description = "the ingress port which is running https"
-  default     = "443"
 }
 
 variable "internal" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,7 @@ variable "dns_zone" {
 
 variable "listeners" {
   description = "A collection of maps which has port, node_port, protocol and cidr"
+  type        = "list"
 }
 
 variable "attach_elb" {


### PR DESCRIPTION
- fixing up the proxy protocol ports
- updating the type of the listeners
- separating out the rules from the listeners
- fixing up the cidr, must be an array
- changing to a vpc id rather than tags
- updating the subnets filter to use a direct one to one
- hardcoding the instance port for protocol proxy the mergekey is too… 