### PR TITLE
Support providing a list of ASG names for the ELB attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Module usage:
 
 | Name | Description | Default | Required |
 |------|-------------|:-----:|:-----:|
-| attach_elb | Autoscaling group name used to find the autoscaling group to attach ELB | `` | no |
+| attach_elb | List of autoscaling group names used to find the autoscaling group to attach ELB | `<list>` | no |
 | connection_draining | Whether the ELB should drain connections | `true` | no |
 | connection_draining_timeout | The timeout for draining connections from the ELB | `120` | no |
 | cross_zone | Should the ELB create be cross zone load balancing | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,7 @@ resource "aws_proxy_protocol_policy" "proxy_protocol" {
   load_balancer  = "${aws_elb.elb.name}"
 }
 
-## Find autoscaling group to attach
+## Find autoscaling group(s) to attach
 data "aws_autoscaling_groups" "groups" {
   count = "${length(var.attach_elb) > 0 ? 1 : 0}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -33,8 +33,8 @@ variable "egress" {
 }
 
 variable "attach_elb" {
-  description = "Autoscaling group name used to find the autoscaling group to attach ELB"
-  default     = ""
+  description = "List of autoscaling group names used to find the autoscaling group to attach ELB"
+  default     = []
 }
 
 variable "health_check_port" {


### PR DESCRIPTION
**Breaking Change:**
- `attach_elb` supports a list of strings rather than just a string